### PR TITLE
feat: product page open on click. fallback page for unmatched query

### DIFF
--- a/src/components/app/app.ts
+++ b/src/components/app/app.ts
@@ -107,11 +107,12 @@ export default class App {
     this.setContent(PAGES.CATALOG, this.catalogView.getElement());
   }
 
-  private loadProductPage() {
+  private loadProductPage(id?: string) {
     // TODO: connect productID from Catalog Page to Product Page 177a75d9-7bcc-4800-8031-91ac81f2bd29
     // 30b29e00-020c-41aa-8da5-250ae76d2f39
     // 5673e423-c01e-4b35-9ef0-86b1043d08b4
-    const product = new ProductView(this.clientApi, '177a75d9-7bcc-4800-8031-91ac81f2bd29').getElement();
+    const productId = id || '81b1bf51-40bd-4598-a12c-e7f5096b9e79';
+    const product = new ProductView(this.clientApi, productId).getElement();
     this.setContent(PAGES.PRODUCT, product);
   }
 

--- a/src/components/router/Router.ts
+++ b/src/components/router/Router.ts
@@ -14,25 +14,26 @@ export default class Router {
     this.startInit();
   }
 
-  public navigate(url: string) {
+  public navigate(url: string, productId = '') {
     this.state.pushState(url);
-    this.processUrl(this.currentPath);
+    this.processUrl(this.currentPath, productId);
+    console.log(this.currentPath);
   }
 
-  private processUrl(url: string): void {
+  private processUrl(url: string, productId = ''): void {
     if (this.signedInUserAccess(`/${url}`) || this.signedOutUserAccess(`/${url}`)) {
       this.state.replaceState(PAGES.MAIN);
       this.routeTo(PAGES.MAIN);
       return;
     }
-    this.routeTo(url);
+    this.routeTo(url, productId);
   }
 
   public stateDeleteToken(): void {
     this.state.deleteAccessToken();
   }
 
-  private routeTo(path: string) {
+  private routeTo(path: string, productId = '') {
     const request = this.parseUrl(path);
     let pathToFind = request.resource === '' ? `/${request.path}` : `${request.path}/${request.resource}`;
     let route = this.routes.find((item) => item.path === pathToFind);
@@ -53,7 +54,10 @@ export default class Router {
     } else {
       this.state.setPageTitle(route.path);
     }
-
+    if (route.path === PAGES.PRODUCT) {
+      route.callback(productId);
+      return;
+    }
     route.callback();
   }
 

--- a/src/components/router/utils/Routes.ts
+++ b/src/components/router/utils/Routes.ts
@@ -88,8 +88,8 @@ export default class Routes {
       },
       {
         path: `${PAGES.PRODUCT}`,
-        callback: () => {
-          this.callbacks.loadProductPage();
+        callback: (id?: string) => {
+          this.callbacks.loadProductPage(id as string);
         },
       },
     ];

--- a/src/components/router/utils/pages.ts
+++ b/src/components/router/utils/pages.ts
@@ -17,7 +17,7 @@ const PAGES: PagesInterface = {
 
   CATEGORY: '/catalog/category',
   CATEGORIES: 'catalog/category',
-  PRODUCT: '/catalog/product',
+  PRODUCT: 'catalog/product',
 };
 
 export default PAGES;

--- a/src/components/utils/Client.ts
+++ b/src/components/utils/Client.ts
@@ -343,7 +343,7 @@ export default class ClientAPI {
 
   public async getAllCardsData() {
     try {
-      const data = await this.apiRoot.products().get().execute();
+      const data = await this.apiRoot.productProjections().get().execute();
       if (data.statusCode === 200) {
         return data.body.results;
       }
@@ -426,11 +426,12 @@ export default class ClientAPI {
   public async getSpecificGenreById(id: string) {
     const query = {
       queryArgs: {
-        where: `categories(id="${id}")`,
+        filter: `categories.id:"${id}"`,
+        limit: 100,
       },
     };
     try {
-      const data = await this.apiRoot.productProjections().get(query).execute();
+      const data = await this.apiRoot.productProjections().search().get(query).execute();
       if (data.statusCode === 200) {
         const response = data.body;
         return response;
@@ -541,7 +542,6 @@ export default class ClientAPI {
   }
 
   public async fetchFilterQuary(endPoints: EndPointsObject) {
-    console.log(endPoints);
     const query = {
       queryArgs: {
         filter: endPoints.filter,

--- a/src/components/view/pages/catalog/catalog-params.ts
+++ b/src/components/view/pages/catalog/catalog-params.ts
@@ -124,7 +124,7 @@ const catalogParams = {
     title: {
       tag: 'h4',
       cssClasses: ['no-res__title'],
-      textContent: 'Sorry, no result found',
+      textContent: 'Sorry, no results found!',
     },
     message: {
       tag: 'p',

--- a/src/components/view/product-page/ProductView.ts
+++ b/src/components/view/product-page/ProductView.ts
@@ -7,6 +7,7 @@ import View from '../View';
 import productParams from './product-params';
 import sliderParams from './slider-params';
 import Modal from '../../utils/Modal';
+import PAGES from '../../router/utils/pages';
 
 export default class ProductView extends View {
   private clientAPI: ClientAPI;
@@ -31,7 +32,7 @@ export default class ProductView extends View {
   private renderInnerWrapper(): void {
     const wrapper = new ElementCreator(wrapperParams);
     const innerWrapper = new ElementCreator(productParams.innerWrapper);
-
+    wrapper.setAttribute('href', PAGES.PRODUCT);
     this.injectProductSection(innerWrapper);
 
     wrapper.getElement().classList.add('product__wrapper');

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -68,7 +68,7 @@ export type PagesInterface = {
 
 export type Route = {
   path: string;
-  callback: (key?: string) => void;
+  callback: (id?: string) => void;
 };
 
 export type UserRequest = {
@@ -112,6 +112,10 @@ export type EndPointsObject = {
   filter: string[];
 };
 
+export type ImageArr = {
+  url?: string;
+};
+
 export interface QueryObject extends PrefetchedAttributes<string> {
   price: string[];
 }
@@ -127,6 +131,6 @@ export type RouteCallbacks = {
   loadNotFoundPage: () => void;
   loadCatalogPage: () => void;
   logoutUser: () => void;
-  loadProductPage: () => void;
-  mountCategory: (key: string) => void;
+  loadProductPage: (id: string) => void;
+  mountCategory: (id: string) => void;
 };


### PR DESCRIPTION
Product page open on click. Fallback page for unmatched query with automatic redirect back after 5 sec.

## Description

This PR adds product page functionality open on click at product card. Fallback page implement for failed query. Minor improvements and TS code refactor.


## What type of PR is this?
- [x] Feature                 🍕 
- [ ] Bug Fix                 🐛
- [ ] Documentation Update    📝
- [ ] Style                   🎨
- [ ] ‍Code Refactor           🧑‍💻
- [ ] Performance Improvements🔥
- [ ] Test                    ✅
- [ ] Build                   🤖
- [ ] Chore (Release)         📦

## Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
Link to task description
-->

## Desktop Screenshots/Recordings
![2023-09-05_03-13-06](https://github.com/NastiaCandor/eCommerce-Application/assets/106710399/ff734795-49c0-4593-a406-5d6633972b61)
![2023-09-05_03-13-13](https://github.com/NastiaCandor/eCommerce-Application/assets/106710399/d846e9c5-e0cd-410a-be62-3e2d088fbe14)

<!-- Visual changes require screenshots -->

## Added tests?

- [ ] yes                            👍
- [x] no, because they aren't needed 🙅
- [ ] no, but I'll do it later       💁
- [ ] no, because I need help        🙋
      
<!-- 
If tests added please describe what they do and on what functions/methodes
-->

### Please, ensure what you commit follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) structural guidline.
### The resulting commit must have structure:
> #### &lt;type&gt;[optional scope]: &lt;short description&gt;
> #### [optional body]
> #### [optional footer(s)]
